### PR TITLE
Re-use relations to avoid issues with postgres

### DIFF
--- a/app/models/lab_tech/observation.rb
+++ b/app/models/lab_tech/observation.rb
@@ -4,6 +4,9 @@ module LabTech
 
     belongs_to :result, class_name: "LabTech::Result", foreign_key: :result_id, optional: true
 
+    scope :timed_out,   -> {     where(exception_class: 'Timeout::Error') }
+    scope :other_error, -> { where.not(exception_class: 'Timeout::Error') }
+
     serialize :value
 
     def raised_error?


### PR DESCRIPTION
This PR fixes a compatibility issue with Postgres.

MySQL allows values to be quoted with `'` and `"`, while Postgres does not accept this. Furthermore, using a `merge` d scope allows us to avoid generating this sql ourselves.

The `is_timeout` removal in `result.rb` is a potentially breaking change. Happy to recreate that if necessary.