### PR TITLE
add warning for folks using the latest Rails security patches

### DIFF
--- a/lib/lab_tech/engine.rb
+++ b/lib/lab_tech/engine.rb
@@ -2,5 +2,21 @@ module LabTech
   class Engine < ::Rails::Engine
     isolate_namespace LabTech
     config.generators.api_only = true
+
+    config.after_initialize do
+      required_serializable_classes = [
+        ActiveSupport::Duration,
+        ActiveSupport::TimeWithZone,
+        ActiveSupport::TimeZone,
+        Time,  
+      ]
+      
+      missing_classes = required_serializable_classes - Rails.configuration.active_record.yaml_column_permitted_classes
+
+      if missing_classes.any?
+        puts "Please add #{missing_classes.join(', ')} to your Rails.configuration.active_record.yaml_column_permitted_classes.".red      
+        puts "LabTech will break your application horribly unless you do.".red      
+      end
+    end
   end
 end


### PR DESCRIPTION
Hi Sam!

Started trying LabTech at work recently and it went poorly. The latest Rails security patches
use `safe_load` when loading yaml, so all classes that go into a yaml-serialized DB column
need to be allow-listed.

I don't know if this warning design is the *best* design for warning folks about this trap,
but I figured it was a starting point and that it would be nicer to submit a PR instead of
just throwing the issue over the wall. 
