### PR TITLE
Update result.rb

### DIFF
--- a/app/models/lab_tech/result.rb
+++ b/app/models/lab_tech/result.rb
@@ -115,7 +115,7 @@ module LabTech
     def record_simple_stats(scientist_result)
       cont, cands = scientist_result.control, scientist_result.candidates
 
-      self.equivalent = cands.all? { |cand| cont.equivalent_to?(cand, &experiment.comparator) }
+      self.equivalent = cands.all? { |cand| cont.equivalent_to?(cand, comparator=experiment.comparator) }
 
       raised = ->(scientist_observation) { scientist_observation.exception.present? }
       self.raised_error = !raised.(cont) && cands.any?(&raised)

--- a/app/models/lab_tech/result.rb
+++ b/app/models/lab_tech/result.rb
@@ -115,7 +115,7 @@ module LabTech
     def record_simple_stats(scientist_result)
       cont, cands = scientist_result.control, scientist_result.candidates
 
-      self.equivalent = cands.all? { |cand| cont.equivalent_to?(cand, comparator=experiment.comparator) }
+      self.equivalent = cands.all? { |cand| cont.equivalent_to?(cand, comparator = experiment.comparator) }
 
       raised = ->(scientist_observation) { scientist_observation.exception.present? }
       self.raised_error = !raised.(cont) && cands.any?(&raised)


### PR DESCRIPTION
### What
Pass `experiment.comparator` no longer as a block via `&experiment.comparator` but as a proc to the `comparator` argument of the `Observation.equivalent_to?` method.

### Why
[This PR](https://github.com/github/scientist/pull/77) of the scientist gem from Oct 2021 changed the interface of the `equivalent_to?` method which no longer transforms an optional block into the `comparator` proc. Instead, one has to pass the comparator directly as a proc. Without that change, the `comparator` variable of `equivalent_to?` keeps its default value `nil` which leads to incorrect comparisons, e.g. `Result.equivalent = false` even though `experiment.comparator` returns `true`.

### Note
We should also increase the minimal required scientist version in the `Gemfile.lock` as the interface change is not backward compatible. According to [this](https://github.com/github/scientist/commit/8a0195f1267504cc36f51eb13a6d6cda19b3d97e) commit we need at least 1.6.1 but it's 1.6.0 now.