### PR TITLE
chore: [sc-22733] Upgrade Lead Manager to Ruby 3.2.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,8 @@ GEM
       rspec-support (~> 3.10)
     rspec-support (3.10.1)
     scientist (1.6.0)
-    sqlite3 (1.4.1)
+    sqlite3 (1.6.2)
+      mini_portile2 (~> 2.8.0)
     table_print (1.5.6)
     thor (1.2.1)
     timeout (0.3.2)
@@ -174,7 +175,7 @@ DEPENDENCIES
   awesome_print
   lab_tech!
   rspec-rails (~> 4.0)
-  sqlite3
+  sqlite3 (~> 1.6.2)
   table_print
 
 BUNDLED WITH

--- a/lab_tech.gemspec
+++ b/lab_tech.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rails",     ">= 5.1.0"
   spec.add_dependency "scientist", "~> 1.3"
 
-  spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "sqlite3", "~> 1.6.2"
   spec.add_development_dependency "rspec-rails", "~> 4.0"
   spec.add_development_dependency "awesome_print"
   spec.add_development_dependency "table_print"

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -19,7 +19,13 @@ require "lab_tech"
 module Dummy
   class Application < Rails::Application
     # Initialize configuration defaults for [current] Rails version.
-    config.load_defaults 5.1
+    config.load_defaults 6.1
+
+    config.active_record.yaml_column_permitted_classes = [
+      Time, Symbol, ActiveSupport::HashWithIndifferentAccess,
+      ActiveSupport::TimeWithZone, ActiveSupport::TimeZone,
+      ActiveSupport::Duration
+    ]
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
Story details: https://app.shortcut.com/realgeekshq/story/22733

Mostly just bumping dependency versions but also had to add `yaml_column_permitted_classes` to the dummy app to get the tests to pass